### PR TITLE
support Ruby 2.4's frozen string literals (1.4.x branch)

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,3 +20,5 @@ jobs:
         bundle install
     - name: Run test
       run: rake compile test
+      env:
+        RUBYOPT: "--enable-frozen-string-literal --debug=frozen-string-literal"

--- a/lib/racc/grammarfileparser.rb
+++ b/lib/racc/grammarfileparser.rb
@@ -427,7 +427,7 @@ module Racc
     $raccs_print_type = false
 
     def scan_action
-      buf = ''
+      buf = String.new
       nest = 1
       pre = nil
       @in_block = 'action'

--- a/lib/racc/parserfilegenerator.rb
+++ b/lib/racc/parserfilegenerator.rb
@@ -235,7 +235,7 @@ module Racc
     end
 
     def unique_separator(id)
-      sep = "...end #{id}/module_eval..."
+      sep = String.new "...end #{id}/module_eval..."
       while @used_separator.key?(sep)
         sep.concat sprintf('%02x', rand(255))
       end
@@ -329,7 +329,7 @@ module Racc
       # TODO: this can be made a LOT more clean with a simple split/map
       sep  = "\n"
       nsep = ",\n"
-      buf  = ''
+      buf  = String.new
       com  = ''
       ncom = ','
       co   = com

--- a/lib/racc/statetransitiontable.rb
+++ b/lib/racc/statetransitiontable.rb
@@ -196,7 +196,7 @@ module Racc
     def mkmapexp(arr)
       i = ii = 0
       as = arr.size
-      map = ''
+      map = String.new
       maxdup = RE_DUP_MAX
       curr = nil
       while i < as


### PR DESCRIPTION
Note this change is made relative to the 1-4-stable branch.

It would be great to cut an updated 1.4.x release after merging this in.
