### PR TITLE
appveyor.yml - fix build error, add trunk

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,27 +10,38 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ps: |
       $rv = $env:ruby_version 
-      if ( $rv -lt '24' ) {
-        gem install minitest hoe rake-compiler rubocop:0.68.1 --no-document --conservative
-      } else {
-        gem install minitest hoe rake-compiler rubocop        --no-document --conservative
+      if ($rv -eq '_trunk') {
+        $trunk_uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z'
+        (New-Object Net.WebClient).DownloadFile($trunk_uri, 'C:\ruby_trunk.7z')
+        7z.exe x C:\ruby_trunk.7z -oC:\Ruby_trunk
       }
-      if ( $rv.EndsWith('-x64') ) {
+      if ( $rv.EndsWith('-x64') -or ($rv -eq '_trunk') ) {
         C:/msys64/usr/bin/pacman -S --noconfirm --needed --noprogressbar mingw-w64-x86_64-ragel
         $env:PATH = "C:/Ruby$rv/bin;$env:PATH;C:/msys64/mingw64/bin"
       } else {
         C:/msys64/usr/bin/pacman -S --noconfirm --needed --noprogressbar mingw-w64-i686-ragel
         $env:PATH = "C:/Ruby$rv/bin;$env:PATH;C:/msys64/mingw32/bin"
       }
+  - gem install minitest hoe:3.17.2 rake-compiler rubocop --no-document --conservative
+
+build_script:
 
 test_script:
   - rake -rdevkit test
 
+on_finish:
+  - ruby -v
+
 environment:
   matrix:
-    - ruby_version: "24"
-    - ruby_version: "24-x64"
-    - ruby_version: "25"
-    - ruby_version: "25-x64"
-    - ruby_version: "26"
-    - ruby_version: "26-x64"
+    - ruby_version: 24
+    - ruby_version: 24-x64
+    - ruby_version: 25
+    - ruby_version: 25-x64
+    - ruby_version: 26
+    - ruby_version: 26-x64
+    - ruby_version: _trunk
+
+matrix:
+  allow_failures:
+    - ruby_version: _trunk


### PR DESCRIPTION
Hoe 3.18.0 won't work with Ruby 2.4, and causes false positives on CI, as the tests DO NOT RUN.  It has been fixed in master.

Fixed other Appveyor issue, added trunk.