### PR TITLE
Remove `add_development_dependency` from gemspec

### DIFF
--- a/racc.gemspec
+++ b/racc.gemspec
@@ -99,9 +99,4 @@ DESC
   else
     s.extensions = ["ext/racc/cparse/extconf.rb"]
   end
-
-  s.add_development_dependency("rake-compiler", [">= 0.4.1"])
-  s.add_development_dependency("minitest", ["~> 4.7"])
-  s.add_development_dependency("rdoc", [">= 4.0", "< 7"])
-  s.add_development_dependency("hoe", ["~> 3.18"])
 end


### PR DESCRIPTION
They were initially intentionally removed in 72c3390fdaa294a85ef90db333e21b62b9623759, but then they got unintentionally (at least judging from the commit message) readded in 34b4e6d77b83892de8ea4061d21f0b70ec876613.