### PR TITLE
Return `nil` for all syntax errors

### DIFF
--- a/ext/racc/cparse/cparse.c
+++ b/ext/racc/cparse/cparse.c
@@ -605,7 +605,7 @@ parse_main(struct cparse_params *v, VALUE tok, VALUE val, int resume)
   user_yyerror:
     if (v->errstatus == 3) {
         if (v->t == vFINAL_TOKEN) {
-            v->retval = Qfalse;
+            v->retval = Qnil;
             v->fin = CP_FIN_EOT;
             return;
         }


### PR DESCRIPTION
Currently returns `nil` for most syntax errors, except it returns `false` when end of source is reached. This PR fixes this, but I couldn't find any tests, so I opened #135.
