### PR TITLE
Turn debugging off

### DIFF
--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -324,7 +324,7 @@ module Racc
     # It must 'yield' the token, which format is [TOKEN-SYMBOL, VALUE].
     class_eval %{
     def yyparse(recv, mid)
-      #{Racc_YY_Parse_Method}(recv, mid, _racc_setup(), true)
+      #{Racc_YY_Parse_Method}(recv, mid, _racc_setup(), false)
     end
     }
 


### PR DESCRIPTION
This doesn't affect the C implementation, as `D_puts` is a macro that depends on an extra `DEBUG` flag.
Ruby implementation has no debug info.
Java implementation has debug info and that would systematically spit out for `yyparse`... This turns it off, and cleans up the ridiculously long CI logs for that platform.