### PR TITLE
Fixed the licenses field of gemspec

### DIFF
--- a/racc.gemspec
+++ b/racc.gemspec
@@ -15,7 +15,7 @@ DESC
   s.authors = ["Minero Aoki", "Aaron Patterson"]
   s.email = [nil, "aaron@tenderlovemaking.com"]
   s.homepage = "http://i.loveruby.net/en/projects/racc/"
-  s.licenses = ["MIT"]
+  s.licenses = ["Ruby", "BSD-2-Clause"]
   s.executables = ["racc"]
   s.files = [
     "COPYING", "ChangeLog",


### PR DESCRIPTION
I missed to fix the license filed with https://github.com/ruby/racc/commit/cc7fe952a6b1fc2ef43477674fa13f2d9d99e818