### PR TITLE
[Fixes #133] Tweak readme to remove 'optional' requirement

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,8 +16,6 @@
 == Requirement
 
   *  Ruby 1.8.x or later.
- (*) make and C compiler.
-
 
 == Installation
 
@@ -36,9 +34,9 @@
 
   You can install Racc into your favorite directory by giving
   options to setup.rb. e.g.
-  
+
     $ ruby setup.rb config --prefix=/usr
-  
+
   For details, try "ruby setup.rb --help".
 
 


### PR DESCRIPTION
The `(*)` in the readme was probably to show this requirement isn't actually a requirement, but probably best to remove that altogether.