### PR TITLE
CI: use jruby-9.2.17.0

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, head, jruby-9.2.16.0, jruby-head ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, head, jruby-9.2.17.0, jruby-head ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.17.0**.

[JRuby 9.2.17.0 release blog post](https://www.jruby.org/2021/03/29/jruby-9-2-17-0.html)