### PR TITLE
README: Drop RubyForge link

### DIFF
--- a/README.ja.rdoc
+++ b/README.ja.rdoc
@@ -1,7 +1,6 @@
 = Racc
 
 * http://i.loveruby.net/en/projects/racc/
-* http://racc.rubyforge.org/
 
 == DESCRIPTION:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,7 +1,6 @@
 = Racc
 
 * http://i.loveruby.net/en/projects/racc/
-* http://racc.rubyforge.org/
 
 == DESCRIPTION:
 


### PR DESCRIPTION
RubyForge is no longer.

This PR removes the defunct link to that website.