### PR TITLE
Add missing check for rb_block_call()

### DIFF
--- a/ext/racc/cparse/extconf.rb
+++ b/ext/racc/cparse/extconf.rb
@@ -3,6 +3,7 @@
 
 require 'mkmf'
 
+have_func('rb_block_call')
 have_func('rb_ary_subseq')
 
 create_makefile 'racc/cparse'


### PR DESCRIPTION
* It used to be hardcoded since 0affbf9d2c7c5c618b8d3fe191e74d9ae8ad22fc but got removed in 23abf3d3fb82afcc26d35769f0dec59dd46de4bb
* This means that since that second commit, rb_iterate() was used unintentionally.

Before this fix, it would cause [failures](https://github.com/rubocop/rubocop-ast/runs/2985886851) in TruffleRuby, since https://github.com/oracle/truffleruby/commit/e7ddba79cc64f7beea8a34ef6c14d50d444399f7 (`rb_iterate()` is obsolete since 1.9 https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#label-Control+Structure, https://bugs.ruby-lang.org/issues/18025)

It would be great to have a release with this fix soon to fix that, do you think that's possible @hsbt @tenderlove?