### PR TITLE
Prefer __dir__ over File.dirname(__FILE__)

### DIFF
--- a/test/assets/mof.y
+++ b/test/assets/mof.y
@@ -563,9 +563,9 @@ end # class Parser
 require 'strscan'
 require 'rubygems'
 require 'cim'
-require File.join(File.dirname(__FILE__), 'result')
-require File.join(File.dirname(__FILE__), 'scanner')
-require File.join(File.dirname(__FILE__), 'case')
+require File.join(__dir__, 'result')
+require File.join(__dir__, 'scanner')
+require File.join(__dir__, 'case')
 
 ---- inner ----
 

--- a/test/case.rb
+++ b/test/case.rb
@@ -10,7 +10,7 @@ require 'timeout'
 
 module Racc
   class TestCase < Test::Unit::TestCase
-    PROJECT_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+    PROJECT_DIR = File.expand_path(File.join(__dir__, '..'))
 
     test_dir = File.join(PROJECT_DIR, 'test')
     test_dir = File.join(PROJECT_DIR, 'racc') unless File.exist?(test_dir)

--- a/test/regress/mof
+++ b/test/regress/mof
@@ -12,9 +12,9 @@ require 'racc/parser.rb'
 require 'strscan'
 require 'rubygems'
 require 'cim'
-require File.join(File.dirname(__FILE__), 'result')
-require File.join(File.dirname(__FILE__), 'scanner')
-require File.join(File.dirname(__FILE__), 'case')
+require File.join(__dir__, 'result')
+require File.join(__dir__, 'scanner')
+require File.join(__dir__, 'case')
 
 module MOF
   class Parser < Racc::Parser

--- a/test/test_chk_y.rb
+++ b/test/test_chk_y.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), 'case'))
+require File.expand_path(File.join(__dir__, 'case'))
 
 module Racc
   class TestChkY < TestCase

--- a/test/test_grammar_file_parser.rb
+++ b/test/test_grammar_file_parser.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), 'case'))
+require File.expand_path(File.join(__dir__, 'case'))
 
 module Racc
   class TestGrammarFileParser < TestCase

--- a/test/test_racc_command.rb
+++ b/test/test_racc_command.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), 'case'))
+require File.expand_path(File.join(__dir__, 'case'))
 
 module Racc
   class TestRaccCommand < TestCase

--- a/test/test_scan_y.rb
+++ b/test/test_scan_y.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), 'case'))
+require File.expand_path(File.join(__dir__, 'case'))
 
 module Racc
   class TestScanY < TestCase


### PR DESCRIPTION
This PR is a tiny syntactic style change.

Perhaps it's easier to read.