### PR TITLE
CI: Add JRuby 9.3, use bundler-cache

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,15 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, 2.5, head, jruby-9.2.19.0, jruby-head ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5, head, jruby-9.2.19.0, jruby-9.3.1.0, jruby-head ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # 'bundle install' and cache        
     - name: Run test
-      run: rake compile test
+      run: bundle exec rake compile test
       continue-on-error: ${{ matrix.ruby == 'jruby-head' }}


### PR DESCRIPTION
This PR adds the bundler-cache feature, and extends the matrix with [JRuby 9.3.1.0](https://www.jruby.org/2021/10/13/jruby-9-3-1-0.html).