### PR TITLE
Only initialize constants when not defined yet

### DIFF
--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -185,8 +185,8 @@ module Racc
 
   class Parser
 
-    Racc_Runtime_Version = ::Racc::VERSION
-    Racc_Runtime_Core_Version_R = ::Racc::VERSION
+    Racc_Runtime_Version = ::Racc::VERSION unless defined?(Racc_Runtime_Version)
+    Racc_Runtime_Core_Version_R = ::Racc::VERSION unless defined?(Racc_Runtime_Core_Version_R)
 
     begin
       if Object.const_defined?(:RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
@@ -204,10 +204,10 @@ module Racc
         raise LoadError, 'selecting ruby version of racc runtime core'
       end
 
-      Racc_Main_Parsing_Routine    = :_racc_do_parse_c # :nodoc:
-      Racc_YY_Parse_Method         = :_racc_yyparse_c # :nodoc:
-      Racc_Runtime_Core_Version    = Racc_Runtime_Core_Version_C # :nodoc:
-      Racc_Runtime_Type            = 'c' # :nodoc:
+      Racc_Main_Parsing_Routine    = :_racc_do_parse_c unless defined?(Racc_Main_Parsing_Routine) # :nodoc:
+      Racc_YY_Parse_Method         = :_racc_yyparse_c unless defined?(Racc_YY_Parse_Method) # :nodoc:
+      Racc_Runtime_Core_Version    = Racc_Runtime_Core_Version_C unless defined?(Racc_Runtime_Core_Version) # :nodoc:
+      Racc_Runtime_Type            = 'c' unless defined?(Racc_Runtime_Type) # :nodoc:
     rescue LoadError
       Racc_Main_Parsing_Routine    = :_racc_do_parse_rb
       Racc_YY_Parse_Method         = :_racc_yyparse_rb


### PR DESCRIPTION
When using embedded racc runtime I got the following warnings when using the embedded racc runtime

```
racc/parser.rb:188: warning: already initialized constant Racc::Parser::Racc_Runtime_Version
path/lib64/ruby/2.5.0/racc/parser.rb:184: warning: previous definition of Racc_Runtime_Version was here
racc/parser.rb:189: warning: already initialized constant Racc::Parser::Racc_Runtime_Core_Version_R
path/lib64/ruby/2.5.0/racc/parser.rb:187: warning: previous definition of Racc_Runtime_Core_Version_R was here
racc/parser.rb:207: warning: already initialized constant Racc::Parser::Racc_Main_Parsing_Routine
path/lib64/ruby/2.5.0/racc/parser.rb:200: warning: previous definition of Racc_Main_Parsing_Routine was here
racc/parser.rb:208: warning: already initialized constant Racc::Parser::Racc_YY_Parse_Method
path/lib64/ruby/2.5.0/racc/parser.rb:201: warning: previous definition of Racc_YY_Parse_Method was here
racc/parser.rb:209: warning: already initialized constant Racc::Parser::Racc_Runtime_Core_Version
path/lib64/ruby/2.5.0/racc/parser.rb:202: warning: previous definition of Racc_Runtime_Core_Version was here
racc/parser.rb:210: warning: already initialized constant Racc::Parser::Racc_Runtime_Type
path/lib64/ruby/2.5.0/racc/parser.rb:204: warning: previous definition of Racc_Runtime_Type was here
```