### PR TITLE
Update github action, run CI weekly, don't abort all builds when 1 failed

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,11 +1,17 @@
 name: ubuntu
 
-on: [push, pull_request]
-
+on: 
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * SUN'
+  workflow_dispatch:
+  
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '3.0', 2.7, 2.6, 2.5, head, jruby-9.2.19.0, jruby-9.3.1.0, jruby-head ]
     steps:


### PR DESCRIPTION
- Run the CI weekly, helps to detect problems due to changed dependencies
- Don't abort all builds when 1 failed