### PR TITLE
Fix flag to `Regexp.new`

### DIFF
--- a/lib/racc/statetransitiontable.rb
+++ b/lib/racc/statetransitiontable.rb
@@ -216,7 +216,7 @@ module Racc
         end
         i = ii
       end
-      Regexp.compile(map, 'n')
+      Regexp.compile(map, nil, 'n')
     end
 
     def set_table(entries, dummy, tbl, chk, ptr)


### PR DESCRIPTION
Probably intended to pass encoding "none".