### PR TITLE
Fix documentation directory name in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,7 +59,7 @@
       $ ruby calc
 
   ... Does it work?
-  For details of Racc, see HTML documents placed under 'rdoc/en/'
+  For details of Racc, see HTML documents placed under 'doc/en/'
   and sample grammar files under 'sample/'.
 
 


### PR DESCRIPTION
There’s “doc/en” directory so it should be the correct name.