### PR TITLE
Get rid of anonymous eval calls

### DIFF
--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -260,11 +260,11 @@ module Racc
     #     def next_token
     #       @q.shift
     #     end
-    class_eval %{
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
     def do_parse
       #{Racc_Main_Parsing_Routine}(_racc_setup(), false)
     end
-    }
+    RUBY
 
     # The method to fetch next token.
     # If you use #do_parse method, you must implement #next_token.
@@ -322,11 +322,11 @@ module Racc
     #
     # RECEIVER#METHOD_ID is a method to get next token.
     # It must 'yield' the token, which format is [TOKEN-SYMBOL, VALUE].
-    class_eval %{
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
     def yyparse(recv, mid)
       #{Racc_YY_Parse_Method}(recv, mid, _racc_setup(), false)
     end
-    }
+    RUBY
 
     def _racc_yyparse_rb(recv, mid, arg, c_debug)
       action_table, action_check, action_default, action_pointer,

--- a/test/assets/cast.y
+++ b/test/assets/cast.y
@@ -636,14 +636,14 @@ restrict return short signed sizeof static struct switch typedef union
 
   def self.feature(name)
     attr_writer "#{name}_enabled"
-    class_eval <<-EOS
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
       def enable_#{name}
         @#{name}_enabled = true
       end
       def #{name}_enabled?
         @#{name}_enabled
       end
-    EOS
+    RUBY
   end
   private_class_method :feature
 

--- a/test/regress/cast
+++ b/test/regress/cast
@@ -96,14 +96,14 @@ restrict return short signed sizeof static struct switch typedef union
 
   def self.feature(name)
     attr_writer "#{name}_enabled"
-    class_eval <<-EOS
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
       def enable_#{name}
         @#{name}_enabled = true
       end
       def #{name}_enabled?
         @#{name}_enabled
       end
-    EOS
+    RUBY
   end
   private_class_method :feature
 


### PR DESCRIPTION
Things declared in anonymous eval are always annoying to locate. (profilers, etc)

cc @hsbt 