### PR TITLE
Remove ErrorSymbolValue reference

### DIFF
--- a/lib/racc/grammar.rb
+++ b/lib/racc/grammar.rb
@@ -993,10 +993,6 @@ module Racc
         @to_s = '$end'
         @serialized = 'false'
         @string = false
-      when ErrorSymbolValue
-        @to_s = 'error'
-        @serialized = 'Object.new'
-        @string = false
       else
         raise ArgumentError, "unknown symbol value: #{value.class}"
       end


### PR DESCRIPTION
I cannot find where this is defined.  I'm guessing neither this nor the else branch is ever hit.  I only found out when testing VM changes, which had a bug that exposed this.