### PR TITLE
Exclude jruby-head on macOS

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,6 +37,7 @@ jobs:
           - {os: macos-latest, ruby: truffleruby }
           - {os: macos-latest, ruby: truffleruby-head }
           - {os: macos-latest, ruby: jruby }
+          - {os: macos-latest, ruby: jruby-head }
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
It keeps timing out, for example https://github.com/ruby/racc/actions/runs/4616310390/jobs/8192616239#step:4:213