### PR TITLE
Embed racc/info.rb too

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,11 +39,17 @@ end
 file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb'] do |t|
   source = 'lib/racc/parser.rb'
 
+  text = File.read(source)
+  text.gsub!(/^require '(.*)'$/) do
+    %[unless $".find {|p| p.end_with?('/#$1.rb')}\n$".push '#$1.rb'\n#{File.read("lib/#{$1}.rb")}\nend\n]
+  rescue
+    $&
+  end
   open(t.name, 'wb') { |io|
     io.write(<<-eorb)
 module Racc
   PARSER_TEXT = <<'__end_of_file__'
-#{File.read(source)}
+#{text}
 __end_of_file__
 end
     eorb

--- a/test/test_parser_text.rb
+++ b/test/test_parser_text.rb
@@ -1,0 +1,10 @@
+require File.expand_path(File.join(__dir__, 'case'))
+
+module Racc
+  class TestRaccParserText < TestCase
+    def test_parser_text_require
+      assert_not_match(/^require/, Racc::PARSER_TEXT)
+      ruby "-I#{LIB_DIR}", "-rracc/parser-text", %[-e$:.clear], %[-eeval(Racc::PARSER_TEXT)]
+    end
+  end
+end


### PR DESCRIPTION
Make scripts generated by `racc -E` runnable without other racc runtimes.
`racc/cparse` will be ignored unless loadable.