### PR TITLE
Embedded path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ def jruby?
   Object.const_defined?(:RUBY_ENGINE) and 'jruby' == RUBY_ENGINE
 end
 
-file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb'] do |t|
+file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', __FILE__] do |t|
   source = 'lib/racc/parser.rb'
 
   text = File.read(source)

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', __FILE__] do |t|
 
   text = File.read(source)
   text.gsub!(/^require '(.*)'$/) do
-    %[unless $".find {|p| p.end_with?('/#$1.rb')}\n$".push '#$1.rb'\n#{File.read("lib/#{$1}.rb")}\nend\n]
+    %[unless $".find {|p| p.end_with?('/#$1.rb')}\n$".push "\#{__dir__}/#$1.rb"\n#{File.read("lib/#{$1}.rb")}\nend\n]
   rescue
     $&
   end

--- a/lib/racc/parserfilegenerator.rb
+++ b/lib/racc/parserfilegenerator.rb
@@ -135,8 +135,8 @@ module Racc
 
     def embed_library(src)
       line %[###### #{src.filename} begin]
-      line %[unless $".index '#{src.filename}']
-      line %[$".push '#{src.filename}']
+      line %[unless $".find {|p| p.end_with?('/#{src.filename}')}]
+      line %[$".push "\#{__dir__}/#{src.filename}"]
       put src, @params.convert_line?
       line %[end]
       line %[###### #{src.filename} end]

--- a/test/case.rb
+++ b/test/case.rb
@@ -75,9 +75,9 @@ module Racc
       end
     end
 
-    def assert_exec(asset)
+    def assert_exec(asset, **opts)
       file = File.basename(asset, '.y')
-      ruby "-I#{LIB_DIR}", "#{@TAB_DIR}/#{file}"
+      ruby "-I#{LIB_DIR}", "-rracc/parser", "#{@TAB_DIR}/#{file}", **opts
     end
 
     def strip_version(source)
@@ -101,8 +101,12 @@ module Racc
       ruby "-I#{LIB_DIR}", "-S", RACC, *arg, **opt
     end
 
-    def ruby(*arg, **opt)
-      assert_ruby_status(["-C", @TEMP_DIR, *arg], **opt)
+    def ruby(*arg, quiet: false, **opt)
+      if quiet
+        assert_in_out_err(["-C", @TEMP_DIR, *arg], **opt)
+      else
+        assert_ruby_status(["-C", @TEMP_DIR, *arg], **opt)
+      end
     end
   end
 end

--- a/test/test_parser_text.rb
+++ b/test/test_parser_text.rb
@@ -4,7 +4,7 @@ module Racc
   class TestRaccParserText < TestCase
     def test_parser_text_require
       assert_not_match(/^require/, Racc::PARSER_TEXT)
-      ruby "-I#{LIB_DIR}", "-rracc/parser-text", %[-e$:.clear], %[-eeval(Racc::PARSER_TEXT)]
+      assert_in_out_err(%W[-I#{LIB_DIR} -rracc/parser-text -e$:.clear -eeval(Racc::PARSER_TEXT)])
     end
   end
 end

--- a/test/test_racc_command.rb
+++ b/test/test_racc_command.rb
@@ -45,7 +45,7 @@ module Racc
     def test_echk_y
       assert_compile 'echk.y', '-E'
       assert_debugfile 'echk.y', []
-      assert_exec 'echk.y'
+      assert_exec 'echk.y', quiet: true
     end
 
     def test_err_y


### PR DESCRIPTION
Suppress already initialized constant warnings.

```
racc/parser.rb:209: warning: already initialized constant Racc::Parser::Racc_Runtime_Version
```
