### PR TITLE
Add "test-unit-ruby-core" development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source "https://rubygems.org"
 
-group :development do
-  gem "rake", "13.0.6"
-  gem "rake-compiler", "1.2.3"
-  gem "test-unit", "3.6.1"
-  gem "test-unit-ruby-core", "1.0.1"
-end
+gemspec

--- a/racc.gemspec
+++ b/racc.gemspec
@@ -55,4 +55,6 @@ DESC
   else
     s.extensions = ["ext/racc/cparse/extconf.rb"]
   end
+
+  s.add_development_dependency("test-unit-ruby-core")
 end

--- a/racc.gemspec
+++ b/racc.gemspec
@@ -56,5 +56,8 @@ DESC
     s.extensions = ["ext/racc/cparse/extconf.rb"]
   end
 
+  s.add_development_dependency("rake")
+  s.add_development_dependency("rake-compiler", ">= 0.4.1")
+  s.add_development_dependency("test-unit")
   s.add_development_dependency("test-unit-ruby-core")
 end


### PR DESCRIPTION
Apart from properly specifying gem dependencies, this also allows to see on rubygems.org that there actually is some user of `test-unit-ruby-core` gem.

Maybe the `Gemfile` should also use the `gemspec` directive.