### PR TITLE
Update development dependency to avoid ruby 2.5 failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :development do
   gem "rake"
-  gem "rake-compiler", ">= 0.4.1"
+  gem "rake-compiler", "1.2.3"
   gem "test-unit"
   gem "test-unit-ruby-core"
 end


### PR DESCRIPTION
rake-compiler v1.2.4 broke ruby 2.5 compatibility

See https://github.com/rake-compiler/rake-compiler/issues/224

Fixes broken CI, see https://github.com/ruby/racc/actions/runs/5736303218/job/15545626178#step:4:27 for example