### PR TITLE
dep: pin development dependencies, and enable dependabot for gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "rake"
+  gem "rake", "13.0.6"
   gem "rake-compiler", "1.2.3"
-  gem "test-unit"
-  gem "test-unit-ruby-core"
+  gem "test-unit", "3.6.1"
+  gem "test-unit-ruby-core", "1.0.1"
 end


### PR DESCRIPTION
The recent failure of CI when rake-compiler made a new release was surprising. I'd like to rely on dependabot PRs to tell us when a dependency change introduces failures.