### PR TITLE
Check `rake build` on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,4 @@ jobs:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
     - run: bundle exec rake compile test
+    - run: bundle exec rake build


### PR DESCRIPTION
Sometimes `rake build` is broken. For example in v1.7.2, mismatch of "cparse-jruby.jar" path between racc.gemspec and Rakefile makes `rake build` failed.
Add a check on CI to detect such problem in advance.

This is an example of failure detected by CI.
https://github.com/yui-knk/racc/actions/runs/6740737770/job/18324268757