### PR TITLE
Fix locations of `expect` param in docs

### DIFF
--- a/doc/en/grammar.en.rdoc
+++ b/doc/en/grammar.en.rdoc
@@ -131,8 +131,8 @@ Racc supports Bison's "expect" directive to declare the expected
 number of shift/reduce conflicts.
 --
 class MyParser
-rule
   expect 3
+rule
     :
     :
 --

--- a/doc/en/grammar2.en.rdoc
+++ b/doc/en/grammar2.en.rdoc
@@ -127,8 +127,8 @@ Racc has bison's "expect" directive.
   # Example
 
   class MyParser
-  rule
     expect 3
+  rule
       :
       :
 


### PR DESCRIPTION
`expect` can be placed before `rule` not in `rule`.