### PR TITLE
'lib/racc/parser-text.rb' depends on 'lib/racc/info.rb'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ def jruby?
   Object.const_defined?(:RUBY_ENGINE) and 'jruby' == RUBY_ENGINE
 end
 
-file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', __FILE__] do |t|
+file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', 'lib/racc/info.rb', __FILE__] do |t|
   source = 'lib/racc/parser.rb'
 
   text = File.read(source)


### PR DESCRIPTION
In the rake task, `require 'racc/info'` is expanded to actual file contents. Then 'lib/racc/parser-text.rb' depends on 'lib/racc/info.rb'.