### PR TITLE
Reformat the rdoc so it renders correctly both locally and on github.

### DIFF
--- a/doc/en/grammar.en.rdoc
+++ b/doc/en/grammar.en.rdoc
@@ -15,48 +15,47 @@ supported: Ruby style (`# ...`) and C style (`/* ... */`).
 == Class Block
 
 The class block is formed like this:
---
-class CLASS_NAME
-  [precedence table]
-  [token declarations]
-  [expected number of S/R conflict]
-  [options]
-  [semantic value conversion]
-  [start rule]
-rule
-  GRAMMARS
---
+
+  class CLASS_NAME
+    [precedence table]
+    [token declarations]
+    [expected number of S/R conflict]
+    [options]
+    [semantic value conversion]
+    [start rule]
+  rule
+    GRAMMARS
+
 CLASS_NAME is a name of parser class.
 This is the name of generating parser class.
 
 If CLASS_NAME includes '::', Racc outputs module clause.
 For example, writing "class M::C" causes creating the code below:
---
-module M
-  class C
-    :
-    :
+
+  module M
+    class C
+      :
+      :
+    end
   end
-end
---
 
 == Grammar Block
 
 The grammar block describes the grammar
 to be understood by parser.  Syntax is:
---
-(token): (token) (token) (token).... (action)
 
-(token): (token) (token) (token).... (action)
-       | (token) (token) (token).... (action)
-       | (token) (token) (token).... (action)
---
+  (token): (token) (token) (token).... (action)
+
+  (token): (token) (token) (token).... (action)
+         | (token) (token) (token).... (action)
+         | (token) (token) (token).... (action)
+
 (action) is an action which is executed when its (token)s are found.
 (action) is a ruby code block, which is surrounded by braces:
---
-{ print val[0]
-  puts val[1] }
---
+
+  { print val[0]
+    puts val[1] }
+
 Note that you cannot use '%' string, here document, '%r' regexp in action.
 
 Actions can be omitted.
@@ -66,20 +65,20 @@ A return value of action is a value of left side value ($$).
 It is value of result, or returned value by "return" statement.
 
 Here is an example of whole grammar block.
---
-rule
-  goal: definition rules source { result = val }
 
-  definition: /* none */   { result = [] }
-    | definition startdesig  { result[0] = val[1] }
-    | definition
-             precrule   # this line continue from upper line
-      {
-        result[1] = val[1]
-      }
+  rule
+    goal: definition rules source { result = val }
 
-  startdesig: START TOKEN
---
+    definition: /* none */   { result = [] }
+      | definition startdesig  { result[0] = val[1] }
+      | definition
+               precrule   # this line continue from upper line
+        {
+          result[1] = val[1]
+        }
+
+    startdesig: START TOKEN
+
 You can use following special local variables in action.
 
   * result ($$)
@@ -99,45 +98,43 @@ DO NOT MODIFY this stack unless you know what you are doing.
 
 This function is equal to '%prec' in yacc.
 To designate this block:
---
-prechigh
-  nonassoc '++'
-  left     '*' '/'
-  left     '+' '-'
-  right    '='
-preclow
---
+
+  prechigh
+    nonassoc '++'
+    left     '*' '/'
+    left     '+' '-'
+    right    '='
+  preclow
+
 `right' is yacc's %right, `left' is yacc's %left.
 
 `=' + (symbol) means yacc's %prec:
---
-prechigh
-  nonassoc UMINUS
-  left '*' '/'
-  left '+' '-'
-preclow
 
-rule
-  exp: exp '*' exp
-     | exp '-' exp
-     | '-' exp       =UMINUS   # equals to "%prec UMINUS"
-         :
-         :
---
+  prechigh
+    nonassoc UMINUS
+    left '*' '/'
+    left '+' '-'
+  preclow
+
+  rule
+    exp: exp '*' exp
+       | exp '-' exp
+       | '-' exp       =UMINUS   # equals to "%prec UMINUS"
+           :
+           :
 
 == expect
 
 Racc supports Bison's "expect" directive to declare the expected
 number of shift/reduce conflicts.
---
-class MyParser
-  expect 3
-rule
-    :
-    :
---
-Then warnings are issued only when the effective number of conflicts differs.
 
+  class MyParser
+    expect 3
+  rule
+      :
+      :
+
+Then warnings are issued only when the effective number of conflicts differs.
 
 == Declaring Tokens
 
@@ -145,17 +142,16 @@ Declaring tokens avoids many bugs.
 
 Racc outputs warnings for declared tokens that do not exist, or existing tokens not declared.
 The syntax is:
---
-token TOKEN_NAME AND_IS_THIS
-      ALSO_THIS_IS AGAIN_AND_AGAIN THIS_IS_LAST
---
+
+  token TOKEN_NAME AND_IS_THIS
+        ALSO_THIS_IS AGAIN_AND_AGAIN THIS_IS_LAST
 
 == Options
 
 You can write options for racc command in your racc file.
---
-options OPTION OPTION ...
---
+
+  options OPTION OPTION ...
+
 Options are:
 
   * omit_action_call
@@ -179,32 +175,29 @@ Token symbols are, as default,
 
 You can change this default using a "convert" block.
 Here is an example:
---
-convert
-  PLUS 'PlusClass'      # We use PlusClass for symbol of `PLUS'
-  MIN  'MinusClass'     # We use MinusClass for symbol of `MIN'
-end
---
+
+  convert
+    PLUS 'PlusClass'      # We use PlusClass for symbol of `PLUS'
+    MIN  'MinusClass'     # We use MinusClass for symbol of `MIN'
+  end
+
 We can use almost all ruby value can be used by token symbol,
 except 'false' and 'nil'.  These are causes unexpected parse error.
 
 If you want to use String as token symbol, special care is required.
 For example:
---
-convert
-  class '"cls"'            # in code, "cls"
-  PLUS '"plus\n"'          # in code, "plus\n"
-  MIN  "\"minus#{val}\""   # in code, \"minus#{val}\"
-end
---
+
+  convert
+    class '"cls"'            # in code, "cls"
+    PLUS '"plus\n"'          # in code, "plus\n"
+    MIN  "\"minus#{val}\""   # in code, \"minus#{val}\"
+  end
 
 == Start Rule
 
 '%start' in yacc. This changes the start symbol.
---
-start real_target
---
 
+  start real_target
 
 == User Code Block
 
@@ -213,14 +206,13 @@ There are three user code blocks, "header" "inner" and "footer".
 
 User code blocks are introduced by four '-' at the beginning of a line,
 followed by a single-word name:
---
----- header
-  ruby statement
-  ruby statement
-  ruby statement
 
----- inner
-  ruby statement
-     :
-     :
---
+  ---- header
+    ruby statement
+    ruby statement
+    ruby statement
+
+  ---- inner
+    ruby statement
+       :
+       :


### PR DESCRIPTION
The current formatting (esp code blocks) looks bad on github and just
stops before the first code block locally.