### PR TITLE
Support `error_on_expect_mismatch` declaration in Racc grammar file

### DIFF
--- a/bin/racc
+++ b/bin/racc
@@ -193,6 +193,9 @@ def main
     end
 
     profiler.report
+    if states.should_error_on_expect_mismatch?
+      raise Racc::CompileError, "#{states.grammar.n_expected_srconflicts} shift/reduce conflicts are expected but #{states.n_srconflicts} shift/reduce conflicts exist"
+    end
   rescue Racc::Error, Errno::ENOENT, Errno::EPERM => err
     raise if $DEBUG or debug_flags.any?
     lineno = err.message.slice(/\A\d+:/).to_s

--- a/lib/racc/grammar.rb
+++ b/lib/racc/grammar.rb
@@ -27,6 +27,7 @@ module Racc
       @rules   = []  # :: [Rule]
       @start   = nil
       @n_expected_srconflicts = nil
+      @error_on_expect_mismatch = nil
       @prec_table = []
       @prec_table_closed = false
       @closed = false
@@ -36,6 +37,7 @@ module Racc
     attr_reader :start
     attr_reader :symboltable
     attr_accessor :n_expected_srconflicts
+    attr_accessor :error_on_expect_mismatch
 
     def [](x)
       @rules[x]

--- a/lib/racc/grammarfileparser.rb
+++ b/lib/racc/grammarfileparser.rb
@@ -76,6 +76,9 @@ module Racc
                         raise CompileError, "`expect' seen twice"
                       end
                       @grammar.n_expected_srconflicts = num
+                    }\
+                  | seq(:ERROR_ON_EXPECT_MISMATCH) {|*|
+                      @grammar.error_on_expect_mismatch = true
                     }
 
     g.convdef     = seq(:symbol, :STRING) {|sym, code|
@@ -493,6 +496,7 @@ module Racc
       'options'  => :OPTION,
       'start'    => :START,
       'expect'   => :EXPECT,
+      'error_on_expect_mismatch' => :ERROR_ON_EXPECT_MISMATCH,
       'class'    => :CLASS,
       'rule'     => :RULE,
       'end'      => :END

--- a/lib/racc/state.rb
+++ b/lib/racc/state.rb
@@ -73,6 +73,10 @@ module Racc
           (n_srconflicts() != @grammar.n_expected_srconflicts)
     end
 
+    def should_error_on_expect_mismatch?
+      should_report_srconflict? && @grammar.error_on_expect_mismatch
+    end
+
     def srconflict_exist?
       n_srconflicts() != 0
     end

--- a/test/assets/error_on_expect_mismatch.y
+++ b/test/assets/error_on_expect_mismatch.y
@@ -1,0 +1,8 @@
+class E
+  expect 0
+  error_on_expect_mismatch
+rule
+  list: inlist inlist
+  inlist:
+        | A
+end

--- a/test/test_racc_command.rb
+++ b/test/test_racc_command.rb
@@ -108,6 +108,13 @@ module Racc
       assert_debugfile 'expect.y', [1,0,0,0,1]
     end
 
+    def test_error_on_expect_mismatch
+      assert_raise_with_message(Test::Unit::AssertionFailedError, /0 shift\/reduce conflicts are expected but 1 shift\/reduce conflicts exist/) {
+        assert_compile 'error_on_expect_mismatch.y'
+      }
+      assert_debugfile 'error_on_expect_mismatch.y', [1,0,0,0,0]
+    end
+
     def test_nullbug1_y
       assert_compile 'nullbug1.y'
       assert_debugfile 'nullbug1.y', [0,0,0,0]


### PR DESCRIPTION
`expect` warns the difference between expected S/R conflicts count
and actual count however racc command exits with success.
racc command will exit with failure if `error_on_expect_mismatch` declaration
is specified therefore build process of racc user will also fail.