### PR TITLE
Exclude 2.5 on macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           - {os: windows-latest, ruby: truffleruby}
           - {os: windows-latest, ruby: jruby-head}
           - {os: windows-latest, ruby: jruby }
+          - {os: macos-latest, ruby: '2.5' }
           - {os: macos-latest, ruby: truffleruby }
           - {os: macos-latest, ruby: truffleruby-head }
           - {os: macos-latest, ruby: jruby }


### PR DESCRIPTION
Now macos-latest is macos-14 which runs on M1, and older versions are not provided for ARM.