### PR TITLE
Change encode EUC-JP to UTF-8

### DIFF
--- a/sample/calc-ja.y
+++ b/sample/calc-ja.y
@@ -1,7 +1,7 @@
 #
 #
 # A simple calculator, version 2.
-# This file contains Japanese characters (encoding=EUC-JP).
+# This file contains Japanese characters.
 
 class Calculator2
   prechigh
@@ -51,8 +51,8 @@ end
 
 ---- footer
 
-puts 'Ä¶¹ë²ÚÅÅÂî 2 ¹æµ¡'
-puts 'Q ¤Ç½ªÎ»¤·¤Ş¤¹'
+puts 'è¶…è±ªè¯é›»å“ 2 å·æ©Ÿ'
+puts 'Q ã§çµ‚äº†ã—ã¾ã™'
 calc = Calculator2.new
 while true
   print '>>> '; $stdout.flush


### PR DESCRIPTION
After testing Racc as per the instructions in README.ja.rdoc, I noticed the following failures:

```
❯ ruby -v
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
❯ racc -ocalc.rb sample/calc-ja.y
❯ ruby calc.rb
calc.rb: calc.rb:197: invalid multibyte char (UTF-8) (SyntaxError)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:197: invalid multibyte char (UTF-8)
calc.rb:198: invalid multibyte char (UTF-8)
calc.rb:198: invalid multibyte char (UTF-8)
calc.rb:198: invalid multibyte char (UTF-8)
calc.rb:198: invalid multibyte char (UTF-8)
calc.rb:198: invalid multibyte char (UTF-8)
calc.rb:198: invalid multibyte char (UTF-8)
```