### PR TITLE
Fix a typo

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,7 +4,7 @@
 
 == DESCRIPTION:
 
-  Racc is a LALR(1) parser generator.
+  Racc is an LALR(1) parser generator.
   It is written in Ruby itself, and generates Ruby program.
 
 == Requirement

--- a/doc/en/racc.en.rhtml
+++ b/doc/en/racc.en.rhtml
@@ -17,7 +17,7 @@
 </p>
 
 <p>
-Racc (Ruby yACC) is a LALR(1) parser generator for Ruby.
+Racc (Ruby yACC) is an LALR(1) parser generator for Ruby.
 Version 1.4.x is stable release.
 </p>
 <p>

--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -19,7 +19,7 @@ unless defined?(::ParseError)
   ParseError = Racc::ParseError # :nodoc:
 end
 
-# Racc is a LALR(1) parser generator.
+# Racc is an LALR(1) parser generator.
 # It is written in Ruby itself, and generates Ruby programs.
 #
 # == Command-line Reference

--- a/racc.gemspec
+++ b/racc.gemspec
@@ -9,9 +9,9 @@ end
 Gem::Specification.new do |s|
   s.name = "racc"
   s.version = Racc::VERSION
-  s.summary = "Racc is a LALR(1) parser generator"
+  s.summary = "Racc is an LALR(1) parser generator"
   s.description = <<DESC
-Racc is a LALR(1) parser generator.
+Racc is an LALR(1) parser generator.
   It is written in Ruby itself, and generates Ruby program.
 
   NOTE: Ruby 1.8.x comes with Racc runtime module.  You


### PR DESCRIPTION
As introduced in the GitHub sidebar (https://github.com/ruby/racc), `an LALR(1) parser generator` seems to be correct.
