### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/racc

### DIFF
--- a/racc.gemspec
+++ b/racc.gemspec
@@ -44,6 +44,7 @@ DESC
   s.required_ruby_version = ">= 2.5"
   s.rdoc_options = ["--main", "README.rdoc"]
   s.extra_rdoc_files = ["README.ja.rdoc", "README.rdoc"]
+  s.metadata["changelog_uri"] = "https://github.com/ruby/racc/releases"
 
   if RUBY_PLATFORM =~ /java/
     s.files << 'lib/java/racc/cparse-jruby.jar'


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/racc which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/