### PR TITLE
Undocument embedded parser

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,8 @@ file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', 'lib/racc/info.rb', __F
 
   text = File.read(source)
   text.sub!(/\A# *frozen[-_]string[-_]literal:.*\n/, '')
-  text.gsub!(/^require '(.*)'$/) do
+  text.gsub!(/(^#.*\n)+(?=module )/, "#--\n")
+    text.gsub!(/^require '(.*)'$/) do
     lib = $1
     code = File.read("lib/#{lib}.rb")
     code.sub!(/\A(?:#.*\n)+/, '')
@@ -37,8 +38,10 @@ file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', 'lib/racc/info.rb', __F
   rescue
     $&
   end
+  text << "#++\n"
   File.open(t.name, 'wb') { |io|
     io.write(<<-eorb)
+# :stopdoc:
 module Racc
   PARSER_TEXT = <<'__end_of_file__'
 #{text}


### PR DESCRIPTION
The embedded parser in parser-text.rb includes the document about `racc` command, which has no sense when embedded.
Remove the document and stop taking documents for its methods.