### PR TITLE
Fix test failures by racc/cparse was loaded from the standard library, but is not part of the default gems starting from Ruby 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :development do
+  gem "racc"
   gem "rake", "13.0.6"
   gem "rake-compiler", "1.2.3"
   gem "test-unit", "3.6.1"


### PR DESCRIPTION
Fix following failure:

```
❯ ruby -v                                                                      
ruby 3.5.0dev (2024-12-25T10:12:31Z master 8f11d6cbe2) +PRISM [arm64-darwin23]
❯ bundle exec rake test
Failure: test_ifelse(Racc::TestRaccCommand)
/ydah/racc/test/test_racc_command.rb:343:in 'Racc::TestRaccCommand#test_ifelse'
<"1 useless nonterminals:\n" +
"  dummy\n" +
"2 useless rules:\n" +
"  #4 (dummy)\n" +
"  #5 (dummy)\n" +
"1 shift/reduce conflicts\n" +
"Turn on logging with \"-v\" and check \".output\" file for details\n"> expected but was
<"/ydah/racc/lib/racc/parser.rb:195: warning: racc/cparse was loaded from the standard library, but is not part of the default gems starting from Ruby 3.3.0.\n" +
"You can add racc to your Gemfile or gemspec to silence this warning.\n" +
"1 useless nonterminals:\n" +
"  dummy\n" +
"2 useless rules:\n" +
"  #4 (dummy)\n" +
"  #5 (dummy)\n" +
"1 shift/reduce conflicts\n" +
"Turn on logging with \"-v\" and check \".output\" file for details\n">
```