### PR TITLE
Add GitHub Actions workflow for deploying Racc documentation to GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Racc documentation to GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ruby/racc' && !startsWith(github.event_name, 'pull') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984 # v1.196.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Racc
+        run: bundle exec rake docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ target
 lib/java/racc/cparse-jruby.jar
 lib/racc/cparse-jruby.jar
 Gemfile.lock
-html
+_site/

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,8 @@ RDoc::Task.new(:docs) do |rd|
   })
 
   title = "#{spec.name}-#{spec.version} Documentation"
-
   rd.options << "-t #{title}"
+  rd.rdoc_dir = "_site"
 end
 
 def java?


### PR DESCRIPTION
This PR will allow you to review Racc's documentation in the following GH pages: 
https://ruby.github.io/racc/

### Motivations

Currently, the Racc documentation is available below, but does not appear to be maintained. Also, there appears to be no way to check it on the web.
- https://github.com/ruby/racc/blob/213e7edd6e60631b2b126008378c8ce61783d4b4/doc

We would like to deploy the documentation to GitHub pages so that people can view the Racc documentation on the web.

### Future work

Currently, we would like to organize and provide documentation on the web for the docs under docs.