### PR TITLE
Fix Java version mismatch errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,12 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
+    - uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 21
+      if: >-
+        startsWith(matrix.ruby, 'jruby')
     - run: bundle install --jobs 4 --retry 3
     - run: rake test
     - run: rake build

--- a/Rakefile
+++ b/Rakefile
@@ -68,8 +68,15 @@ if jruby?
     lib_dir = ext.lib_dir += "/#{ext.platform}/racc"
     ext.ext_dir = 'ext/racc'
     # source/target jvm
-    ext.source_version = '1.8'
-    ext.target_version = '1.8'
+    if defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new('10.0.0.0')
+      # Use Java 21 for JRuby 10.0.0.0 or higher
+      ext.source_version = '21'
+      ext.target_version = '21'
+    else
+      # Use Java 8 if its lower than JRuby 10.0.0.0
+      ext.source_version = '1.8'
+      ext.target_version = '1.8'
+    end
     jars = ["#{jruby_home}/lib/jruby.jar"] + FileList['lib/*.jar']
     ext.classpath = jars.map { |x| File.expand_path x }.join( ':' )
     ext.name = 'cparse-jruby'


### PR DESCRIPTION
Fixes: https://github.com/ruby/racc/issues/288

We are trying to compile for Java 8 with `-target 1.8 -source 1.8 `at compile time but the JRuby jar file (jruby.jar) is compiled with Java 21

https://github.com/ruby/racc/actions/runs/15127129930/job/42521128864

- Error message: `class file has wrong version 65.0, should be 61.0`
- version 65.0 = Java 21
- version 61.0 = Java 17